### PR TITLE
Update SkoolkitZ80.sublime-syntax

### DIFF
--- a/SkoolkitZ80.sublime-syntax
+++ b/SkoolkitZ80.sublime-syntax
@@ -125,7 +125,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.end.skoolkit
       pop: true
-      
+
   asm_directives:
     - match: '^(@label=)(.+)\b'
       captures:

--- a/SkoolkitZ80.sublime-syntax
+++ b/SkoolkitZ80.sublime-syntax
@@ -120,12 +120,12 @@ contexts:
   inside_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.skoolkit
-    - match: '\.'
+    - match: '(\.)|(\\")'
       scope: constant.character.escape.skoolkit
-    - match: '^(?!")'
+    - match: '"'
       scope: punctuation.definition.string.end.skoolkit
       pop: true
-
+      
   asm_directives:
     - match: '^(@label=)(.+)\b'
       captures:

--- a/SkoolkitZ80.sublime-syntax
+++ b/SkoolkitZ80.sublime-syntax
@@ -122,7 +122,7 @@ contexts:
     - meta_scope: string.quoted.double.skoolkit
     - match: '\.'
       scope: constant.character.escape.skoolkit
-    - match: '"'
+    - match: '^(?!")'
       scope: punctuation.definition.string.end.skoolkit
       pop: true
 

--- a/SkoolkitZ80.sublime-syntax
+++ b/SkoolkitZ80.sublime-syntax
@@ -120,7 +120,7 @@ contexts:
   inside_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.skoolkit
-    - match: '(\.)|(\\")'
+    - match: '\\.'
       scope: constant.character.escape.skoolkit
     - match: '"'
       scope: punctuation.definition.string.end.skoolkit


### PR DESCRIPTION
trying to handle escaped double quotes inside strings, e.g.
`t27010 DEFM "\"))"`

this seems to work for me,
see
![image](https://user-images.githubusercontent.com/2770290/62008832-17de4280-b19b-11e9-84a0-eacccda73739.png)
vs original version
![image](https://user-images.githubusercontent.com/2770290/62008866-507e1c00-b19b-11e9-9359-76c315b83ea6.png)

